### PR TITLE
Updated sqlparse to version 0.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ phonenumberslite==8.12.31
 pipreqs==0.4.10
 pytz==2021.1
 requests==2.26.0
-sqlparse==0.4.1
+sqlparse==0.4.2
 urllib3==1.26.6
 whitenoise==5.3.0
 yarg==0.1.9


### PR DESCRIPTION
This update should fix Github's security alert with sqlparse